### PR TITLE
Fix translation into russian + add ModMenu localizations

### DIFF
--- a/src/main/resources/assets/deathlocation/lang/ru_ru.json
+++ b/src/main/resources/assets/deathlocation/lang/ru_ru.json
@@ -1,7 +1,10 @@
 {
-  "deathlocation.deathmessage": "Вы погибли на X: %d, Y: %d, Z: %d в %s.",
-  "deathlocation.overworld": "Верхнем Мире",
-  "deathlocation.nether": "Нижнем Мире",
-  "deathlocation.end": "Эндер Мире",
-  "deathlocation.copy": "Копировать координаты"
+  "deathlocation.deathmessage": "Вы погибли на координатах X: %d, Y: %d, Z: %d в %s.",
+  "deathlocation.overworld": "Верхнем мире",
+  "deathlocation.nether": "Нижнем мире",
+  "deathlocation.end": "измерении Энда",
+  "deathlocation.copy": "Копировать координаты",
+
+  "modmenu.summaryTranslation.deathlocation":"Вывод в чат координат при смерти игрока.",
+  "modmenu.descriptionTranslation.deathlocation": "Автоматически выводит в чат координаты игрока при его смерти."
 }


### PR DESCRIPTION
- Added missing noun
- Fixed wrong uppercase letters
- Fixed wrong dimension name (according to the official localization, `in the End` may mean `в Энде`, `в измерении Энда`, `в мире Энда` but not `в Эндер Мире`) 
- Added translations for summary and descriptions in ModMenu